### PR TITLE
Require jsonschema (and add version constraints)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: a77e63ee8f93f77d03b5bcb9955ad0b4edda1e5c49d0b11fae6cc66cc1f41a1a
 
 build:
-    number: 0
+    number: 1
     noarch: python
     script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
   run:
     - python >=3.5
     - json5
-    - notebook
+    - notebook >=4.2.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,8 +22,8 @@ requirements:
 
   run:
     - python >=3.5
-    - notebook
     - json5
+    - notebook
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,7 @@ requirements:
   run:
     - python >=3.5
     - json5
+    - jsonschema >=3.0.1
     - notebook >=4.2.0
 
 test:


### PR DESCRIPTION
Fixes https://github.com/conda-forge/jupyterlab_server-feedstock/issues/8

Adds the `jsonschema` requirement with a version constraint. Also constrains the `notebook` version needed. These requirements are [copied from the `setup.py`]( https://github.com/jupyterlab/jupyterlab_server/blob/v1.0.0/setup.py#L43-L45 ).

Note: We need to pull older packages missing these requirements when they should have had them.

cc @blink1073

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
